### PR TITLE
chore: scaffold microservices architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A real-time chess application similar to chess.com, built with React and Node.js.
 
+This project is transitioning from a monolithic backend to a microservices architecture.
+
 ## Features
 
 - Real-time multiplayer chess games
@@ -89,6 +91,27 @@ npm start
 
 ```
 chessapp/
+├── microservices/     # Independent backend services
+│   ├── gateway/            # API Gateway
+│   ├── auth/               # Auth Service
+│   ├── profile/            # User/Profile Service
+│   ├── matchmaking/        # Matchmaking Service
+│   ├── game/               # Game Service (Realtime)
+│   ├── game-coordinator/   # Game Coordinator / Router
+│   ├── game-persistence/   # Game Persistence Service
+│   ├── rating/             # Rating Service
+│   ├── spectator/          # Spectator/Playback Service
+│   ├── ai/                 # AI Move Service
+│   ├── analysis/           # Analysis Service
+│   ├── puzzle/             # Puzzle Service
+│   ├── chat/               # Chat & Presence Service
+│   ├── tournament/         # Tournament Service
+│   ├── clubs/              # Clubs/Teams Service
+│   ├── notifications/      # Notifications Service
+│   ├── fairplay/           # Fair-Play / Anti-Cheat Service
+│   ├── gateway-admin/      # Gateway Admin / Config Service
+│   ├── telemetry/          # Telemetry & Observability
+│   └── media/              # File/Media Service
 ├── frontend/          # React frontend
 │   ├── src/
 │   │   ├── components/    # Reusable components
@@ -96,7 +119,7 @@ chessapp/
 │   │   ├── hooks/         # Custom hooks
 │   │   └── services/      # API services
 │   └── public/
-├── backend/           # Node.js backend
+├── backend/           # Legacy monolith (to be decomposed)
 │   ├── server.js      # Main server file
 │   └── .env           # Environment variables
 └── package.json       # Root package.json for scripts

--- a/microservices/ai/README.md
+++ b/microservices/ai/README.md
@@ -1,0 +1,9 @@
+# AI Move Service (Stockfish Pool)
+
+**Purpose**: Non-blocking AI moves.
+
+**APIs**: `POST /ai/move {fen, level, timeLeft}` → `{uci, thinkMs}`.
+
+**Queue**: Redis/Bull or SQS; pool size = CPU cores.
+
+**Testing**: Time caps, determinism per level.

--- a/microservices/analysis/README.md
+++ b/microservices/analysis/README.md
@@ -1,0 +1,11 @@
+# Analysis Service
+
+**Purpose**: Post-game evals, blunders, accuracy.
+
+**APIs**:
+- `POST /analysis/jobs {gameId}`
+- `GET /analysis/:gameId`
+
+**Data**: JSONB per move annotations; S3 for heavy artifacts.
+
+**Testing**: Throughput under burst; partial results.

--- a/microservices/chat/README.md
+++ b/microservices/chat/README.md
@@ -1,0 +1,12 @@
+# Chat & Presence Service
+
+**Purpose**: In-game chat, lobby, DMs (basic), online status.
+
+**Sockets/APIs**:
+- `chat:send`
+- `GET /chat/history`
+- `GET /presence/:user`
+
+**Data**: Redis presence `presence:{userId}` TTL; Postgres chat (TTL/retention policy).
+
+**Testing**: Flood/rate-limit; moderation hooks.

--- a/microservices/clubs/README.md
+++ b/microservices/clubs/README.md
@@ -1,0 +1,12 @@
+# Clubs/Teams Service
+
+**Purpose**: Clubs, membership, announcements, club matches.
+
+**APIs**:
+- `POST /clubs`
+- `POST /clubs/:id/join`
+- `GET /clubs/:id`
+
+**Data**: `clubs`, `club_members`, `club_matches`.
+
+**Testing**: Permissions; large club listings.

--- a/microservices/fairplay/README.md
+++ b/microservices/fairplay/README.md
@@ -1,0 +1,9 @@
+# Fair-Play / Anti-Cheat Service
+
+**Purpose**: Offline heuristics + engine match stats; flagging.
+
+**Inputs**: recent finished games; user reports.
+
+**Outputs**: `fairplay.flagged{userId, confidence}`.
+
+**Testing**: Precision/recall on sample sets; appeal workflow.

--- a/microservices/game-coordinator/README.md
+++ b/microservices/game-coordinator/README.md
@@ -1,0 +1,11 @@
+# Game Coordinator / Router
+
+**Purpose**: Place new games on nodes; resolve `gameId→node`.
+
+**APIs**:
+- `POST /games` (internal)
+- `GET /routing/:gameId`
+
+**Data**: Redis `route:game:{id}={nodeId}`; `nodes:{id}:capacity`.
+
+**Testing**: Node churn; capacity-aware placement.

--- a/microservices/game-persistence/README.md
+++ b/microservices/game-persistence/README.md
@@ -1,0 +1,11 @@
+# Game Persistence Service
+
+**Purpose**: Durable storage of moves & results; archive.
+
+**Inputs**: `move.appended`, `game.finished` (Kafka/Streams).
+
+**Writes**: Postgres `games` (summary, indexes), Mongo/S3 `game_docs` (pgn/json).
+
+**APIs**: `GET /archive/:gameId` (for export).
+
+**Testing**: Idempotent writes; late events; partition strategy.

--- a/microservices/game/README.md
+++ b/microservices/game/README.md
@@ -1,0 +1,24 @@
+# Game Service (Realtime)
+
+**Purpose**: Host live games; validate moves; manage clocks; emit updates.
+
+**Sockets**:
+- `game:join`
+- `game:move{uci}`
+- `game:state`
+- `game:offer_draw`
+- `game:resign`
+
+**APIs**:
+- `GET /games/:id` (light state)
+- `POST /games/:id/admin/end`
+
+**Events**: `move.appended`, `game.snapshot`, `game.finished`.
+
+**Data**: In‑mem board; Redis snapshot `game:{id}:fen/clock`; ephemeral room membership.
+
+**Scaling**: Socket.io + Redis adapter; sticky sessions via ALB; N× nodes.
+
+**SLOs**: emit p95 <100ms intra‑region.
+
+**Testing**: Race conditions, premove, reconnection, draw rules.

--- a/microservices/gateway-admin/README.md
+++ b/microservices/gateway-admin/README.md
@@ -1,0 +1,12 @@
+# Gateway Admin / Config Service
+
+**Purpose**: Feature flags, rate limits, service registry, JWKS rotation.
+
+**APIs**:
+- `GET /healthz|readyz`
+- `PUT /flags/:key`
+- `GET /registry`
+
+**Data**: DynamoDB/PG; SSM Parameter Store.
+
+**Testing**: Safe rollout (percentage flags), audit logs.

--- a/microservices/matchmaking/README.md
+++ b/microservices/matchmaking/README.md
@@ -1,0 +1,16 @@
+# Matchmaking Service
+
+**Purpose**: Pair players by rating/time control, dynamic window, optional latency bias.
+
+**APIs**:
+- `POST /queue/join`
+- `POST /queue/leave`
+- `GET /queue/state` (debug)
+
+**Events**: emits `match.found {p1,p2,mode,region?}`.
+
+**Data**: Redis sorted sets `mm:{mode}` score=rating, value={playerId, ts}.
+
+**SLOs**: avg <5s; p95 <12s.
+
+**Testing**: Load w/ synthetic users; fairness (winprob ~50%).

--- a/microservices/media/README.md
+++ b/microservices/media/README.md
@@ -1,0 +1,11 @@
+# File/Media Service
+
+**Purpose**: Avatars, PGN exports, analysis files.
+
+**APIs**:
+- `POST /files/sign` (S3 presign)
+- `GET /files/:id` (authz)
+
+**Data**: S3; metadata in Postgres.
+
+**Testing**: Virus scan hooks (optional), signed URL expiry.

--- a/microservices/notifications/README.md
+++ b/microservices/notifications/README.md
@@ -1,0 +1,11 @@
+# Notifications Service
+
+**Purpose**: Email/WebPush/Mobile push dispatch.
+
+**APIs**:
+- `POST /notify`
+- `POST /devices/register`
+
+**Integrations**: SES/SNS, FCM/APNs; topic fan-out.
+
+**Testing**: Dedup/idempotency; backoff.

--- a/microservices/profile/README.md
+++ b/microservices/profile/README.md
@@ -1,0 +1,14 @@
+# User/Profile Service
+
+**Purpose**: Profiles, avatars, preferences, friends/blocks.
+
+**APIs**:
+- `GET/PUT /profiles/:id`
+- `GET /profiles/:id/stats`
+- `POST /friends/:id`
+
+**Data**: `profiles`, `friends(user_id, friend_id, status)`, `blocks`.
+
+**Cache**: Redis by `profile:{id}`.
+
+**Testing**: E2E with Auth; privacy rules.

--- a/microservices/puzzle/README.md
+++ b/microservices/puzzle/README.md
@@ -1,0 +1,12 @@
+# Puzzle Service
+
+**Purpose**: Puzzles, ratings, Rush sessions.
+
+**APIs**:
+- `GET /puzzles/next?userId`
+- `POST /puzzle-rush/start|move|finish`
+- `GET /leaderboards/puzzle-rush`
+
+**Data**: `puzzles(id, fen, solution[], rating, themes[])`.
+
+**Testing**: Anti-repeat; latency under 100ms for next puzzle.

--- a/microservices/rating/README.md
+++ b/microservices/rating/README.md
@@ -1,0 +1,13 @@
+# Rating Service
+
+**Purpose**: Glicko-2 updates per pool.
+
+**Inputs**: `game.finished`.
+
+**APIs**:
+- `GET /ratings/:userId`
+- `POST /ratings/recalc` (admin)
+
+**Data**: `ratings(user_id, pool, rating, rd, vol)`; `rating_history`.
+
+**Testing**: Known cases; convergence for provisional users.

--- a/microservices/spectator/README.md
+++ b/microservices/spectator/README.md
@@ -1,0 +1,11 @@
+# Spectator/Playback Service
+
+**Purpose**: Join mid-game; viewer counts; move backfill.
+
+**APIs**:
+- `GET /games/:id/state`
+- `GET /games/:id/moves?since=n`
+
+**Data**: Redis snapshot; recent move ringbuffer; counts per room.
+
+**Testing**: 10k spectators on hot game; throttled count updates.

--- a/microservices/telemetry/README.md
+++ b/microservices/telemetry/README.md
@@ -1,0 +1,7 @@
+# Telemetry & Observability
+
+**Purpose**: Metrics, traces, logs.
+
+**Stack**: Prometheus, Grafana, OTEL Collector, Loki/ELK, CloudWatch.
+
+**Deliverables**: Golden dashboards (matchmaking, game latency, DB QPS), alerts (SLO burn rate).

--- a/microservices/tournament/README.md
+++ b/microservices/tournament/README.md
@@ -1,0 +1,14 @@
+# Tournament Service
+
+**Purpose**: Swiss/Arena/KO orchestration.
+
+**APIs**:
+- `POST /tournaments`
+- `POST /tournaments/:id/start`
+- `GET /tournaments/:id/standings`
+
+**Events**: `tournament.pairings`; calls Game to spawn.
+
+**Data**: `tournaments`, `participants`, `pairings`, `results`.
+
+**Testing**: Pairing correctness; 1000-player arena throughput.


### PR DESCRIPTION
## Summary
- outline transition to microservices architecture in documentation
- scaffold directories for profile, matchmaking, game, and other backend services

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0b1779ed08326a25e228cc2c17ccf