### PR TITLE
feat(game): add realtime game service skeleton

### DIFF
--- a/microservices/game/controllers/gameController.js
+++ b/microservices/game/controllers/gameController.js
@@ -1,0 +1,21 @@
+const gameService = require('../services/gameService');
+const logger = require('../utils/logger');
+
+async function getGame(req, res) {
+  const { id } = req.params;
+  logger.info('Fetching game snapshot', { id });
+  const snapshot = await gameService.getSnapshot(id);
+  res.json({ id, ...snapshot });
+}
+
+async function endGame(req, res) {
+  const { id } = req.params;
+  logger.info('Admin ending game', { id });
+  await gameService.endGame(id);
+  res.status(204).end();
+}
+
+module.exports = {
+  getGame,
+  endGame
+};

--- a/microservices/game/controllers/gameSocketController.js
+++ b/microservices/game/controllers/gameSocketController.js
@@ -1,0 +1,43 @@
+const gameService = require('../services/gameService');
+const logger = require('../utils/logger');
+
+function register(io) {
+  io.on('connection', (socket) => {
+    socket.on('game:join', async ({ gameId }) => {
+      socket.join(gameId);
+      const snapshot = await gameService.getSnapshot(gameId);
+      socket.emit('game.snapshot', snapshot);
+    });
+
+    socket.on('game:move', async ({ gameId, uci }) => {
+      const result = await gameService.makeMove(gameId, uci);
+      if (!result) return;
+      io.to(gameId).emit('move.appended', { move: result.move });
+      io.to(gameId).emit('game.snapshot', { fen: result.fen, clock: result.clock });
+      if (result.gameOver) {
+        io.to(gameId).emit('game.finished', result.gameOver);
+      }
+    });
+
+    socket.on('game:state', async ({ gameId }) => {
+      const snapshot = await gameService.getSnapshot(gameId);
+      if (snapshot) {
+        socket.emit('game.snapshot', snapshot);
+      }
+    });
+
+    socket.on('game:offer_draw', ({ gameId }) => {
+      io.to(gameId).emit('game.draw_offered');
+    });
+
+    socket.on('game:resign', ({ gameId, player }) => {
+      io.to(gameId).emit('game.finished', {
+        winner: player === 'w' ? 'b' : 'w',
+        reason: 'resign'
+      });
+      gameService.endGame(gameId);
+    });
+  });
+}
+
+module.exports = { register };

--- a/microservices/game/db/redis.js
+++ b/microservices/game/db/redis.js
@@ -1,0 +1,15 @@
+const { createClient } = require('redis');
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+const client = createClient({ url: REDIS_URL });
+
+client.on('error', (err) => console.error('Redis Client Error', err));
+
+async function connect() {
+  if (!client.isOpen) {
+    await client.connect();
+  }
+  return client;
+}
+
+module.exports = { client, connect };

--- a/microservices/game/middleware/asyncHandler.js
+++ b/microservices/game/middleware/asyncHandler.js
@@ -1,0 +1,3 @@
+module.exports = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};

--- a/microservices/game/middleware/validation.js
+++ b/microservices/game/middleware/validation.js
@@ -1,0 +1,11 @@
+const { validationResult } = require('express-validator');
+
+function handleValidation(req, res, next) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  next();
+}
+
+module.exports = { handleValidation };

--- a/microservices/game/models/gameModel.js
+++ b/microservices/game/models/gameModel.js
@@ -1,0 +1,28 @@
+const { client } = require('../db/redis');
+
+async function getSnapshot(id) {
+  const fen = await client.get(`game:${id}:fen`);
+  const clock = await client.get(`game:${id}:clock`);
+  return {
+    fen,
+    clock: clock ? JSON.parse(clock) : null
+  };
+}
+
+async function saveSnapshot(id, fen, clock) {
+  await client.set(`game:${id}:fen`, fen);
+  if (clock) {
+    await client.set(`game:${id}:clock`, JSON.stringify(clock));
+  }
+}
+
+async function deleteSnapshot(id) {
+  await client.del(`game:${id}:fen`);
+  await client.del(`game:${id}:clock`);
+}
+
+module.exports = {
+  getSnapshot,
+  saveSnapshot,
+  deleteSnapshot
+};

--- a/microservices/game/package.json
+++ b/microservices/game/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "chess-game-service",
+  "version": "0.1.0",
+  "description": "Realtime game service for Chess App",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"No tests for game service yet\" && exit 0"
+  },
+  "dependencies": {
+    "chess.js": "^1.0.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-validator": "^7.2.1",
+    "morgan": "^1.10.0",
+    "redis": "^4.6.7",
+    "socket.io": "^4.7.5",
+    "winston": "^3.11.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  }
+}

--- a/microservices/game/routes/gameRoutes.js
+++ b/microservices/game/routes/gameRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { validateGameId } = require('../validations/gameValidation');
+const { handleValidation } = require('../middleware/validation');
+const asyncHandler = require('../middleware/asyncHandler');
+const gameController = require('../controllers/gameController');
+
+const router = express.Router();
+
+router.get('/:id', validateGameId, handleValidation, asyncHandler(gameController.getGame));
+router.post('/:id/admin/end', validateGameId, handleValidation, asyncHandler(gameController.endGame));
+
+module.exports = router;

--- a/microservices/game/server.js
+++ b/microservices/game/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const http = require('http');
+const cors = require('cors');
+const morgan = require('morgan');
+const { Server } = require('socket.io');
+const logger = require('./utils/logger');
+const { connect } = require('./db/redis');
+const gameRoutes = require('./routes/gameRoutes');
+const socketController = require('./controllers/gameSocketController');
+
+const PORT = process.env.PORT || 8080;
+
+async function start() {
+  await connect();
+
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+  app.use(morgan('combined', { stream: { write: (msg) => logger.info(msg.trim()) } }));
+
+  app.use('/games', gameRoutes);
+
+  const server = http.createServer(app);
+  const io = new Server(server, { cors: { origin: '*' } });
+  socketController.register(io);
+
+  app.use((err, req, res, next) => {
+    logger.error(err.message);
+    res.status(500).json({ error: 'Internal Server Error' });
+  });
+
+  server.listen(PORT, () => {
+    logger.info(`Game service listening on ${PORT}`);
+  });
+}
+
+start();

--- a/microservices/game/services/gameService.js
+++ b/microservices/game/services/gameService.js
@@ -1,0 +1,48 @@
+const { Chess } = require('chess.js');
+const gameModel = require('../models/gameModel');
+
+const games = new Map(); // in-memory game state
+
+function getOrCreateGame(id) {
+  let game = games.get(id);
+  if (!game) {
+    game = { chess: new Chess(), clock: { w: 300000, b: 300000 }, moves: [] };
+    games.set(id, game);
+  }
+  return game;
+}
+
+async function getSnapshot(id) {
+  const game = games.get(id);
+  if (game) {
+    return { fen: game.chess.fen(), clock: game.clock, moves: game.moves };
+  }
+  return gameModel.getSnapshot(id);
+}
+
+async function makeMove(id, uci) {
+  const game = getOrCreateGame(id);
+  const move = game.chess.move(uci, { sloppy: true });
+  if (!move) return null;
+  game.moves.push(move.san);
+  await gameModel.saveSnapshot(id, game.chess.fen(), game.clock);
+  const result = {
+    move: move.san,
+    fen: game.chess.fen(),
+    clock: game.clock,
+    gameOver: game.chess.isGameOver() ? { result: game.chess.result ? game.chess.result() : undefined } : null
+  };
+  return result;
+}
+
+async function endGame(id) {
+  games.delete(id);
+  await gameModel.deleteSnapshot(id);
+}
+
+module.exports = {
+  getSnapshot,
+  makeMove,
+  endGame,
+  getOrCreateGame
+};

--- a/microservices/game/utils/logger.js
+++ b/microservices/game/utils/logger.js
@@ -1,0 +1,12 @@
+const { createLogger, transports, format } = require('winston');
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.json()
+  ),
+  transports: [new transports.Console()]
+});
+
+module.exports = logger;

--- a/microservices/game/validations/gameValidation.js
+++ b/microservices/game/validations/gameValidation.js
@@ -1,0 +1,9 @@
+const { param } = require('express-validator');
+
+const validateGameId = [
+  param('id').isString().notEmpty()
+];
+
+module.exports = {
+  validateGameId
+};


### PR DESCRIPTION
## Summary
- restructure realtime game service into layered modules with logger, routes, controllers, services, and models
- add Redis client and winston logging while handling socket events via dedicated controller
- validate game routes before invoking controller logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd microservices/game && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b8e6d1908326809578deeffaaeb0