### PR TITLE
feat: scaffold game persistence service

### DIFF
--- a/microservices/game-persistence/README.md
+++ b/microservices/game-persistence/README.md
@@ -9,3 +9,16 @@
 **APIs**: `GET /archive/:gameId` (for export).
 
 **Testing**: Idempotent writes; late events; partition strategy.
+
+## Development
+
+```bash
+npm install
+npm start
+```
+
+Run the lightweight test suite:
+
+```bash
+npm test
+```

--- a/microservices/game-persistence/__tests__/persistenceService.test.js
+++ b/microservices/game-persistence/__tests__/persistenceService.test.js
@@ -1,0 +1,36 @@
+// microservices/game-persistence/__tests__/persistenceService.test.js
+const assert = require('assert');
+const { handleMoveAppended, handleGameFinished, getArchive, __reset } = require('../services/persistenceService');
+const { getPartition } = require('../kafka/partition');
+
+(async () => {
+  // Idempotent move writes
+  __reset();
+  await handleMoveAppended({ gameId: 'g1', move: { id: 1, san: 'e4' } });
+  await handleMoveAppended({ gameId: 'g1', move: { id: 1, san: 'e4' } });
+  let archive = await getArchive('g1');
+  assert.strictEqual(archive.doc.moves.length, 1, 'Duplicate moves should not be stored');
+
+  // Idempotent game finished writes
+  __reset();
+  await handleGameFinished({ gameId: 'g2', result: '1-0' });
+  await handleGameFinished({ gameId: 'g2', result: '1-0' });
+  archive = await getArchive('g2');
+  assert.strictEqual(archive.summary.result, '1-0', 'Result should be stored once');
+
+  // Late move after game finished
+  __reset();
+  await handleGameFinished({ gameId: 'g3', result: '0-1' });
+  await handleMoveAppended({ gameId: 'g3', move: { id: 1, san: 'e4' } });
+  archive = await getArchive('g3');
+  assert.strictEqual(archive.summary.result, '0-1', 'Result preserved');
+  assert.strictEqual(archive.doc.moves.length, 1, 'Late move should be stored');
+
+  // Partition strategy
+  const p1 = getPartition('gameA', 32);
+  const p2 = getPartition('gameA', 32);
+  assert.strictEqual(p1, p2, 'Partition must be stable per game');
+  assert.ok(p1 >= 0 && p1 < 32, 'Partition within bounds');
+
+  console.log('All tests passed');
+})();

--- a/microservices/game-persistence/controllers/archiveController.js
+++ b/microservices/game-persistence/controllers/archiveController.js
@@ -1,0 +1,16 @@
+// microservices/game-persistence/controllers/archiveController.js
+const { getArchive } = require('../services/persistenceService');
+
+async function getArchiveById(req, res) {
+  try {
+    const archive = await getArchive(req.params.gameId);
+    if (!archive) {
+      return res.status(404).json({ message: 'Game not found' });
+    }
+    res.json(archive);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+}
+
+module.exports = { getArchiveById };

--- a/microservices/game-persistence/database/mongo.js
+++ b/microservices/game-persistence/database/mongo.js
@@ -1,0 +1,16 @@
+// microservices/game-persistence/database/mongo.js
+const docs = new Map();
+
+async function saveGameDoc(gameId, doc) {
+  docs.set(gameId, doc);
+}
+
+async function getGameDoc(gameId) {
+  return docs.get(gameId);
+}
+
+function __reset() {
+  docs.clear();
+}
+
+module.exports = { saveGameDoc, getGameDoc, __reset };

--- a/microservices/game-persistence/database/postgres.js
+++ b/microservices/game-persistence/database/postgres.js
@@ -1,0 +1,16 @@
+// microservices/game-persistence/database/postgres.js
+const summaries = new Map();
+
+async function saveGameSummary(gameId, summary) {
+  summaries.set(gameId, summary);
+}
+
+async function getGameSummary(gameId) {
+  return summaries.get(gameId);
+}
+
+function __reset() {
+  summaries.clear();
+}
+
+module.exports = { saveGameSummary, getGameSummary, __reset };

--- a/microservices/game-persistence/kafka/consumer.js
+++ b/microservices/game-persistence/kafka/consumer.js
@@ -1,0 +1,27 @@
+// microservices/game-persistence/kafka/consumer.js
+const { Kafka } = require('kafkajs');
+const { handleMoveAppended, handleGameFinished } = require('../services/persistenceService');
+
+async function start() {
+  const kafka = new Kafka({
+    clientId: 'game-persistence-service',
+    brokers: (process.env.KAFKA_BROKERS || 'localhost:9092').split(',')
+  });
+  const consumer = kafka.consumer({ groupId: 'game-persistence-service' });
+  await consumer.connect();
+  await consumer.subscribe({ topic: 'move.appended' });
+  await consumer.subscribe({ topic: 'game.finished' });
+  await consumer.run({
+    eachMessage: async ({ topic, message }) => {
+      const event = JSON.parse(message.value.toString());
+      if (topic === 'move.appended') {
+        await handleMoveAppended(event);
+      } else if (topic === 'game.finished') {
+        await handleGameFinished(event);
+      }
+    }
+  });
+  return consumer;
+}
+
+module.exports = { start };

--- a/microservices/game-persistence/kafka/partition.js
+++ b/microservices/game-persistence/kafka/partition.js
@@ -1,0 +1,9 @@
+// microservices/game-persistence/kafka/partition.js
+const crypto = require('crypto');
+
+function getPartition(gameId, partitionCount) {
+  const hash = crypto.createHash('sha1').update(gameId).digest('hex');
+  return parseInt(hash.substring(0, 8), 16) % partitionCount;
+}
+
+module.exports = { getPartition };

--- a/microservices/game-persistence/package.json
+++ b/microservices/game-persistence/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "game-persistence-service",
+  "version": "0.1.0",
+  "description": "Durable storage of chess game moves and results",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node __tests__/persistenceService.test.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.16.3",
+    "mongodb": "^6.5.0",
+    "kafkajs": "^2.2.4",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/microservices/game-persistence/server.js
+++ b/microservices/game-persistence/server.js
@@ -1,0 +1,20 @@
+// microservices/game-persistence/server.js
+const express = require('express');
+const { getArchiveById } = require('./controllers/archiveController');
+const kafkaConsumer = require('./kafka/consumer');
+
+const app = express();
+
+app.get('/archive/:gameId', getArchiveById);
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 8080;
+  app.listen(port, () => {
+    console.log(`Game Persistence Service listening on port ${port}`);
+  });
+  kafkaConsumer.start().catch(err => {
+    console.error('Kafka consumer failed', err);
+  });
+}
+
+module.exports = app;

--- a/microservices/game-persistence/services/persistenceService.js
+++ b/microservices/game-persistence/services/persistenceService.js
@@ -1,0 +1,52 @@
+// microservices/game-persistence/services/persistenceService.js
+const postgres = require('../database/postgres');
+const mongo = require('../database/mongo');
+
+const games = new Map();
+
+async function handleMoveAppended(event) {
+  const { gameId, move } = event;
+  let game = games.get(gameId);
+  if (!game) {
+    game = { moves: [], finished: false };
+    games.set(gameId, game);
+  }
+  if (game.moves.some(m => m.id === move.id)) {
+    return { idempotent: true };
+  }
+  game.moves.push(move);
+  await mongo.saveGameDoc(gameId, { moves: game.moves, result: game.result });
+  return { success: true };
+}
+
+async function handleGameFinished(event) {
+  const { gameId, result } = event;
+  let game = games.get(gameId);
+  if (!game) {
+    game = { moves: [], finished: false };
+    games.set(gameId, game);
+  }
+  if (game.finished) {
+    return { idempotent: true };
+  }
+  game.finished = true;
+  game.result = result;
+  await postgres.saveGameSummary(gameId, { result, moveCount: game.moves.length });
+  await mongo.saveGameDoc(gameId, { moves: game.moves, result });
+  return { success: true };
+}
+
+async function getArchive(gameId) {
+  const summary = await postgres.getGameSummary(gameId);
+  const doc = await mongo.getGameDoc(gameId);
+  if (!summary && !doc) return null;
+  return { summary, doc };
+}
+
+function __reset() {
+  games.clear();
+  postgres.__reset();
+  mongo.__reset();
+}
+
+module.exports = { handleMoveAppended, handleGameFinished, getArchive, __reset };


### PR DESCRIPTION
## Summary
- scaffold game persistence microservice with Express API and Kafka consumer
- persist moves and results to in-memory Postgres/Mongo adapters with idempotent logic
- add partition helper and tests for late events and idempotent writes

## Testing
- `cd microservices/game-persistence && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b903c0848326acf83eb31dd93c87