### PR TITLE
feat: add chat and presence service

### DIFF
--- a/microservices/chat/README.md
+++ b/microservices/chat/README.md
@@ -1,12 +1,24 @@
 # Chat & Presence Service
 
-**Purpose**: In-game chat, lobby, DMs (basic), online status.
+Provides lobby and direct message chat along with simple online presence tracking.
 
-**Sockets/APIs**:
-- `chat:send`
-- `GET /chat/history`
-- `GET /presence/:user`
+## Sockets & APIs
+- `chat:send` – broadcast a chat message to a room
+- `GET /chat/history` – retrieve last 50 messages for a room
+- `GET /presence/:user` – check if a user is online
 
-**Data**: Redis presence `presence:{userId}` TTL; Postgres chat (TTL/retention policy).
+## Architecture
+Follows the flow `request -> logger -> routes -> validation -> controller -> service -> model -> db` for both HTTP and Socket.IO interactions.
 
-**Testing**: Flood/rate-limit; moderation hooks.
+## Data
+- Redis key `presence:{userId}` with configurable TTL
+- PostgreSQL table `chat_messages` for message history
+
+## Running
+```
+PORT=4000 REDIS_URL=redis://localhost:6379 DATABASE_URL=postgresql://chat_user:chat_password@localhost:5432/chat_db npm start
+```
+
+## Notes
+- Basic in-memory rate limiting is applied to chat sends
+- Hooks for moderation and advanced rate limiting can be added

--- a/microservices/chat/controllers/chatController.js
+++ b/microservices/chat/controllers/chatController.js
@@ -1,0 +1,15 @@
+const chatService = require('../services/chatService');
+const logger = require('../utils/logger');
+
+async function getHistory(req, res) {
+  const room = req.query.room || 'lobby';
+  try {
+    const data = await chatService.getHistory(room);
+    res.json({ success: true, data });
+  } catch (err) {
+    logger.error('History error', { error: err.message });
+    res.status(500).json({ success: false, message: 'Could not fetch history' });
+  }
+}
+
+module.exports = { getHistory };

--- a/microservices/chat/controllers/presenceController.js
+++ b/microservices/chat/controllers/presenceController.js
@@ -1,0 +1,15 @@
+const presenceService = require('../services/presenceService');
+const logger = require('../utils/logger');
+
+async function getPresence(req, res) {
+  const user = req.params.user;
+  try {
+    const online = await presenceService.getPresence(user);
+    res.json({ user, online });
+  } catch (err) {
+    logger.error('Presence error', { error: err.message });
+    res.status(500).json({ success: false, message: 'Could not check presence' });
+  }
+}
+
+module.exports = { getPresence };

--- a/microservices/chat/controllers/socketController.js
+++ b/microservices/chat/controllers/socketController.js
@@ -1,0 +1,50 @@
+const chatService = require('../services/chatService');
+const presenceService = require('../services/presenceService');
+const logger = require('../utils/logger');
+
+const messageTimestamps = new Map();
+const RATE_LIMIT_MS = 500;
+
+function handleConnection(io, socket) {
+  const userId = socket.handshake.auth?.userId || socket.id;
+
+  presenceService.markOnline(userId).catch(err =>
+    logger.error('Presence set error', { error: err.message })
+  );
+
+  socket.on('chat:send', async ({ room = 'lobby', message }) => {
+    const last = messageTimestamps.get(userId) || 0;
+    const now = Date.now();
+    if (now - last < RATE_LIMIT_MS) {
+      socket.emit('chat:error', 'Rate limit exceeded');
+      return;
+    }
+    messageTimestamps.set(userId, now);
+
+    // TODO: moderation hooks
+    try {
+      await chatService.sendMessage(room, userId, message);
+      io.to(room).emit('chat:message', {
+        room,
+        senderId: userId,
+        message,
+        createdAt: new Date().toISOString()
+      });
+    } catch (err) {
+      logger.error('Chat send error', { error: err.message });
+      socket.emit('chat:error', 'Message not sent');
+    }
+  });
+
+  socket.on('join', (room) => {
+    socket.join(room);
+  });
+
+  socket.on('disconnect', () => {
+    presenceService.markOffline(userId).catch(err =>
+      logger.error('Redis disconnect error', { error: err.message })
+    );
+  });
+}
+
+module.exports = { handleConnection };

--- a/microservices/chat/db/postgres.js
+++ b/microservices/chat/db/postgres.js
@@ -1,0 +1,21 @@
+const { Pool } = require('pg');
+const logger = require('../utils/logger');
+
+const DATABASE_URL = process.env.DATABASE_URL || 'postgresql://chat_user:chat_password@localhost:5432/chat_db';
+
+const pool = new Pool({ connectionString: DATABASE_URL });
+
+async function init() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS chat_messages (
+    id SERIAL PRIMARY KEY,
+    room TEXT NOT NULL,
+    sender_id TEXT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+  )`);
+  logger.info('Postgres initialized');
+}
+
+init().catch(err => logger.error('Postgres init error', { error: err.message }));
+
+module.exports = pool;

--- a/microservices/chat/db/redis.js
+++ b/microservices/chat/db/redis.js
@@ -1,0 +1,11 @@
+const { createClient } = require('redis');
+const logger = require('../utils/logger');
+
+const REDIS_URL = process.env.REDIS_URL || 'redis://localhost:6379';
+
+const client = createClient({ url: REDIS_URL });
+client.on('error', (err) => logger.error('Redis error', { error: err.message }));
+
+client.connect().then(() => logger.info('Redis connected'));
+
+module.exports = client;

--- a/microservices/chat/middleware/validation.js
+++ b/microservices/chat/middleware/validation.js
@@ -1,0 +1,22 @@
+const { query, param, validationResult } = require('express-validator');
+
+const validate = (validations) => {
+  return async (req, res, next) => {
+    await Promise.all(validations.map(validation => validation.run(req)));
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    next();
+  };
+};
+
+const validateHistory = validate([
+  query('room').optional().isString().trim().isLength({ max: 100 })
+]);
+
+const validatePresence = validate([
+  param('user').isString().trim().notEmpty()
+]);
+
+module.exports = { validateHistory, validatePresence };

--- a/microservices/chat/models/chatModel.js
+++ b/microservices/chat/models/chatModel.js
@@ -1,0 +1,18 @@
+const pool = require('../db/postgres');
+
+async function saveMessage(room, senderId, message) {
+  await pool.query(
+    'INSERT INTO chat_messages (room, sender_id, message) VALUES ($1, $2, $3)',
+    [room, senderId, message]
+  );
+}
+
+async function getHistory(room, limit = 50) {
+  const { rows } = await pool.query(
+    'SELECT sender_id, message, room, created_at FROM chat_messages WHERE room = $1 ORDER BY created_at DESC LIMIT $2',
+    [room, limit]
+  );
+  return rows;
+}
+
+module.exports = { saveMessage, getHistory };

--- a/microservices/chat/models/presenceModel.js
+++ b/microservices/chat/models/presenceModel.js
@@ -1,0 +1,22 @@
+const redis = require('../db/redis');
+
+const PRESENCE_TTL = parseInt(process.env.PRESENCE_TTL || '60', 10);
+
+function presenceKey(userId) {
+  return `presence:${userId}`;
+}
+
+async function setPresence(userId) {
+  await redis.set(presenceKey(userId), 'online', { EX: PRESENCE_TTL });
+}
+
+async function clearPresence(userId) {
+  await redis.del(presenceKey(userId));
+}
+
+async function checkPresence(userId) {
+  const exists = await redis.exists(presenceKey(userId));
+  return exists === 1;
+}
+
+module.exports = { setPresence, clearPresence, checkPresence };

--- a/microservices/chat/package.json
+++ b/microservices/chat/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "chat-service",
+  "version": "1.0.0",
+  "description": "Chat and presence microservice",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.4",
+    "redis": "^4.6.7",
+    "pg": "^8.16.3",
+    "express-rate-limit": "^7.1.5",
+    "express-validator": "^7.2.1",
+    "morgan": "^1.10.0",
+    "winston": "^3.10.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.2"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/microservices/chat/routes/chatRoutes.js
+++ b/microservices/chat/routes/chatRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { validateHistory, validatePresence } = require('../middleware/validation');
+const chatController = require('../controllers/chatController');
+const presenceController = require('../controllers/presenceController');
+
+const router = express.Router();
+
+router.get('/chat/history', validateHistory, chatController.getHistory);
+router.get('/presence/:user', validatePresence, presenceController.getPresence);
+
+module.exports = router;

--- a/microservices/chat/server.js
+++ b/microservices/chat/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+const rateLimit = require('express-rate-limit');
+const morgan = require('morgan');
+
+const logger = require('./utils/logger');
+const chatRoutes = require('./routes/chatRoutes');
+const { handleConnection } = require('./controllers/socketController');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server, { cors: { origin: '*' } });
+
+const PORT = process.env.PORT || 4000;
+
+// Middleware
+app.use(express.json());
+app.use(morgan('combined', { stream: { write: (msg) => logger.info(msg.trim()) } }));
+
+const limiter = rateLimit({ windowMs: 60 * 1000, max: 60 });
+app.use(limiter);
+
+// Routes
+app.use(chatRoutes);
+
+// Socket.io
+io.on('connection', (socket) => handleConnection(io, socket));
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    logger.info(`Chat service listening on port ${PORT}`);
+  });
+}
+
+module.exports = { app, server, io };

--- a/microservices/chat/services/chatService.js
+++ b/microservices/chat/services/chatService.js
@@ -1,0 +1,11 @@
+const chatModel = require('../models/chatModel');
+
+async function getHistory(room) {
+  return chatModel.getHistory(room);
+}
+
+async function sendMessage(room, senderId, message) {
+  await chatModel.saveMessage(room, senderId, message);
+}
+
+module.exports = { getHistory, sendMessage };

--- a/microservices/chat/services/presenceService.js
+++ b/microservices/chat/services/presenceService.js
@@ -1,0 +1,15 @@
+const presenceModel = require('../models/presenceModel');
+
+async function getPresence(userId) {
+  return presenceModel.checkPresence(userId);
+}
+
+async function markOnline(userId) {
+  await presenceModel.setPresence(userId);
+}
+
+async function markOffline(userId) {
+  await presenceModel.clearPresence(userId);
+}
+
+module.exports = { getPresence, markOnline, markOffline };

--- a/microservices/chat/utils/logger.js
+++ b/microservices/chat/utils/logger.js
@@ -1,0 +1,17 @@
+const winston = require('winston');
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json()
+  ),
+  defaultMeta: { service: 'chat-service' },
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.simple(),
+    })
+  ]
+});
+
+module.exports = logger;

--- a/microservices/init-db.sql
+++ b/microservices/init-db.sql
@@ -3,15 +3,18 @@ CREATE DATABASE auth_db;
 CREATE DATABASE profiles_db;
 CREATE DATABASE ratings_db;
 CREATE DATABASE games_db;
+CREATE DATABASE chat_db;
 
 -- Create users for each service (in production, use separate credentials)
 CREATE USER auth_user WITH ENCRYPTED PASSWORD 'auth_password';
 CREATE USER profiles_user WITH ENCRYPTED PASSWORD 'profiles_password';
 CREATE USER ratings_user WITH ENCRYPTED PASSWORD 'ratings_password';
 CREATE USER games_user WITH ENCRYPTED PASSWORD 'games_password';
+CREATE USER chat_user WITH ENCRYPTED PASSWORD 'chat_password';
 
 -- Grant permissions
 GRANT ALL PRIVILEGES ON DATABASE auth_db TO auth_user;
 GRANT ALL PRIVILEGES ON DATABASE profiles_db TO profiles_user;
 GRANT ALL PRIVILEGES ON DATABASE ratings_db TO ratings_user;
 GRANT ALL PRIVILEGES ON DATABASE games_db TO games_user;
+GRANT ALL PRIVILEGES ON DATABASE chat_db TO chat_user;


### PR DESCRIPTION
## Summary
- refactor chat microservice into layered architecture with logging, routes, validation, controllers, services, and models
- connect chat service to PostgreSQL and Redis through dedicated data models
- document chat service architecture and flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd microservices/chat && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b9527a2c832689d6be22379e214b