### PR TITLE
feat: add initial fairplay service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ Thumbs.db
 
 #zip files
 *.zip
+
+microservices/**/package-lock.json

--- a/microservices/fairplay/README.md
+++ b/microservices/fairplay/README.md
@@ -6,4 +6,23 @@
 
 **Outputs**: `fairplay.flagged{userId, confidence}`.
 
+## Endpoints
+- `POST /analyze` – submit finished games with engine match percentages.
+- `POST /report` – submit a user report.
+- `GET /flagged` – retrieve users flagged for potential cheating.
+
+## Architecture
+Request -> logger -> routes -> validation -> controller -> service -> model
+
+## Development
+```
+npm install
+npm start
+```
+
+## Testing
+```
+npm test
+```
+
 **Testing**: Precision/recall on sample sets; appeal workflow.

--- a/microservices/fairplay/controllers/fairplayController.js
+++ b/microservices/fairplay/controllers/fairplayController.js
@@ -1,0 +1,23 @@
+const service = require('../services/fairplayService');
+
+const analyze = (req, res) => {
+  const { games = [] } = req.body;
+  const flagged = service.analyzeGames(games);
+  res.json({ flagged });
+};
+
+const report = (req, res) => {
+  const { userId } = req.body;
+  const result = service.reportUser(userId);
+  res.json({ flagged: !!result, confidence: result?.confidence || 0 });
+};
+
+const getFlagged = (req, res) => {
+  res.json({ flagged: service.getFlagged() });
+};
+
+module.exports = {
+  analyze,
+  report,
+  getFlagged
+};

--- a/microservices/fairplay/middleware/logger.js
+++ b/microservices/fairplay/middleware/logger.js
@@ -1,0 +1,4 @@
+const morgan = require('morgan');
+
+// Simple request logger
+module.exports = morgan('dev');

--- a/microservices/fairplay/middleware/validation.js
+++ b/microservices/fairplay/middleware/validation.js
@@ -1,0 +1,25 @@
+const validateAnalyze = (req, res, next) => {
+  const { games } = req.body || {};
+  if (!Array.isArray(games)) {
+    return res.status(400).json({ error: 'games array required' });
+  }
+  for (const game of games) {
+    if (typeof game.userId !== 'string') {
+      return res.status(400).json({ error: 'game.userId must be a string' });
+    }
+    if (typeof game.engineMatch !== 'number' || game.engineMatch < 0 || game.engineMatch > 1) {
+      return res.status(400).json({ error: 'game.engineMatch must be between 0 and 1' });
+    }
+  }
+  next();
+};
+
+const validateReport = (req, res, next) => {
+  const { userId } = req.body || {};
+  if (!userId) {
+    return res.status(400).json({ error: 'userId required' });
+  }
+  next();
+};
+
+module.exports = { validateAnalyze, validateReport };

--- a/microservices/fairplay/models/fairplayModel.js
+++ b/microservices/fairplay/models/fairplayModel.js
@@ -1,0 +1,25 @@
+const flagged = new Map();
+const reports = new Map();
+
+function flagUser(userId, confidence) {
+  flagged.set(userId, { confidence });
+}
+
+function getFlagged() {
+  return Array.from(flagged.entries()).map(([userId, data]) => ({
+    userId,
+    confidence: data.confidence
+  }));
+}
+
+function incrementReport(userId) {
+  const count = (reports.get(userId) || 0) + 1;
+  reports.set(userId, count);
+  return count;
+}
+
+module.exports = {
+  flagUser,
+  getFlagged,
+  incrementReport
+};

--- a/microservices/fairplay/package.json
+++ b/microservices/fairplay/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fairplay-service",
+  "version": "0.1.0",
+  "description": "Service for fair-play and anti-cheat detection",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
+  }
+}

--- a/microservices/fairplay/routes/fairplay.js
+++ b/microservices/fairplay/routes/fairplay.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const controller = require('../controllers/fairplayController');
+const { validateAnalyze, validateReport } = require('../middleware/validation');
+
+const router = express.Router();
+
+router.post('/analyze', validateAnalyze, controller.analyze);
+router.post('/report', validateReport, controller.report);
+router.get('/flagged', controller.getFlagged);
+
+module.exports = router;

--- a/microservices/fairplay/server.js
+++ b/microservices/fairplay/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const logger = require('./middleware/logger');
+const fairplayRoutes = require('./routes/fairplay');
+
+const app = express();
+app.use(express.json());
+app.use(logger);
+app.use('/', fairplayRoutes);
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Fair-Play service running on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/microservices/fairplay/services/fairplayService.js
+++ b/microservices/fairplay/services/fairplayService.js
@@ -1,0 +1,29 @@
+const { flagUser, getFlagged, incrementReport } = require('../models/fairplayModel');
+
+const FLAG_THRESHOLD = 0.9;
+
+function analyzeGames(games = []) {
+  games.forEach(({ userId, engineMatch = 0 }) => {
+    if (userId && engineMatch >= FLAG_THRESHOLD) {
+      flagUser(userId, Number(engineMatch.toFixed(2)));
+    }
+  });
+  return getFlagged();
+}
+
+function reportUser(userId) {
+  const count = incrementReport(userId);
+  const confidence = 0.8 + count * 0.05;
+  if (confidence >= FLAG_THRESHOLD) {
+    const finalConfidence = Number(Math.min(confidence, 1).toFixed(2));
+    flagUser(userId, finalConfidence);
+    return { userId, confidence: finalConfidence };
+  }
+  return null;
+}
+
+module.exports = {
+  analyzeGames,
+  reportUser,
+  getFlagged
+};

--- a/microservices/fairplay/tests/fairplay.test.js
+++ b/microservices/fairplay/tests/fairplay.test.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Fair-Play Service', () => {
+  test('flags user based on engine match percentage', async () => {
+    const res = await request(app)
+      .post('/analyze')
+      .send({ games: [{ userId: 'player1', engineMatch: 0.95 }] });
+
+    expect(res.body.flagged).toEqual([
+      { userId: 'player1', confidence: 0.95 }
+    ]);
+  });
+
+  test('flags user after multiple reports', async () => {
+    await request(app).post('/report').send({ userId: 'player2' });
+    await request(app).post('/report').send({ userId: 'player2' });
+
+    const flagged = await request(app).get('/flagged');
+    const flaggedUsers = flagged.body.flagged;
+
+    const player2 = flaggedUsers.find(u => u.userId === 'player2');
+    expect(player2).toBeDefined();
+    expect(player2.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+});


### PR DESCRIPTION
## Summary
- restructure fairplay microservice into layered modules with logging, validation, controllers, services, and models
- add request logging and input validation for analysis and reporting
- document architecture and ignore microservice lockfiles

## Testing
- `cd microservices/fairplay && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9836808832696561965bdebcefa