### PR TITLE
feat(media): add initial file service

### DIFF
--- a/microservices/media/config/index.js
+++ b/microservices/media/config/index.js
@@ -1,0 +1,18 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
+module.exports = {
+  server: {
+    port: process.env.PORT || 8080,
+  },
+  aws: {
+    region: process.env.AWS_REGION || 'us-east-1',
+    bucket: process.env.AWS_S3_BUCKET || 'chessapp-media',
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+    urlExpiry: parseInt(process.env.AWS_URL_EXPIRY || '60', 10),
+  },
+  logging: {
+    level: process.env.LOG_LEVEL || 'info',
+  },
+};

--- a/microservices/media/controllers/filesController.js
+++ b/microservices/media/controllers/filesController.js
@@ -1,0 +1,18 @@
+const fileService = require('../services/fileService');
+const logger = require('../utils/logger');
+
+async function signFile(req, res) {
+  const { fileName, contentType } = req.body;
+  const result = await fileService.createSignedUpload(fileName, contentType);
+  logger.info('Upload URL generated', { key: result.key, traceId: req.traceId });
+  res.json(result);
+}
+
+async function getFile(req, res) {
+  const key = req.params.id;
+  const result = await fileService.getSignedDownload(key);
+  logger.info('Download URL generated', { key, traceId: req.traceId });
+  res.json(result);
+}
+
+module.exports = { signFile, getFile };

--- a/microservices/media/middleware/errorHandler.js
+++ b/microservices/media/middleware/errorHandler.js
@@ -1,0 +1,17 @@
+const logger = require('../utils/logger');
+
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+const notFound = (req, res) => {
+  res.status(404).json({ message: 'Not found' });
+};
+
+const errorHandler = (err, req, res, next) => {
+  logger.error(err.message, { stack: err.stack, traceId: req.traceId });
+  const status = err.status || 500;
+  res.status(status).json({ message: err.message || 'Internal server error' });
+};
+
+module.exports = { asyncHandler, notFound, errorHandler };

--- a/microservices/media/middleware/validation.js
+++ b/microservices/media/middleware/validation.js
@@ -1,0 +1,20 @@
+const validateSignRequest = (req, res, next) => {
+  const { fileName, contentType } = req.body;
+  const errors = [];
+  if (!fileName) errors.push('fileName is required');
+  if (!contentType) errors.push('contentType is required');
+  if (errors.length > 0) {
+    return res.status(400).json({ message: errors.join(', ') });
+  }
+  next();
+};
+
+const validateFileId = (req, res, next) => {
+  const { id } = req.params;
+  if (!id) {
+    return res.status(400).json({ message: 'File ID is required' });
+  }
+  next();
+};
+
+module.exports = { validateSignRequest, validateFileId };

--- a/microservices/media/models/fileModel.js
+++ b/microservices/media/models/fileModel.js
@@ -1,0 +1,12 @@
+const files = new Map();
+
+async function save(file) {
+  files.set(file.key, file);
+  return file;
+}
+
+async function get(key) {
+  return files.get(key);
+}
+
+module.exports = { save, get };

--- a/microservices/media/package.json
+++ b/microservices/media/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "chess-media-service",
+  "version": "0.1.0",
+  "description": "File/media service for Chess App",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "jest"
+  },
+  "keywords": [
+    "media",
+    "files",
+    "chess",
+    "microservices"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.556.0",
+    "@aws-sdk/s3-request-presigner": "^3.556.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0",
+    "winston": "^3.11.0",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.2",
+    "supertest": "^6.3.4"
+  },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=8.0.0"
+  }
+}

--- a/microservices/media/routes/files.js
+++ b/microservices/media/routes/files.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/filesController');
+const { validateSignRequest, validateFileId } = require('../middleware/validation');
+const { asyncHandler } = require('../middleware/errorHandler');
+
+router.post('/sign', validateSignRequest, asyncHandler(controller.signFile));
+router.get('/:id', validateFileId, asyncHandler(controller.getFile));
+
+module.exports = router;

--- a/microservices/media/server.js
+++ b/microservices/media/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const helmet = require('helmet');
+const cors = require('cors');
+const morgan = require('morgan');
+const { v4: uuidv4 } = require('uuid');
+
+const config = require('./config');
+const logger = require('./utils/logger');
+const filesRoutes = require('./routes/files');
+const { errorHandler, notFound } = require('./middleware/errorHandler');
+
+const app = express();
+app.use(helmet());
+app.use(cors());
+app.use(express.json({ limit: '10mb' }));
+app.use(morgan('combined', {
+  stream: {
+    write: (message) => logger.info(message.trim()),
+  },
+}));
+
+app.use((req, res, next) => {
+  req.traceId = req.headers['x-trace-id'] || uuidv4();
+  res.setHeader('X-Trace-ID', req.traceId);
+  next();
+});
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', service: 'media-service' });
+});
+
+app.use('/files', filesRoutes);
+
+app.use(notFound);
+app.use(errorHandler);
+
+const port = config.server.port;
+if (require.main === module) {
+  app.listen(port, () => {
+    logger.info(`Media service listening on port ${port}`);
+  });
+}
+
+module.exports = app;

--- a/microservices/media/services/fileService.js
+++ b/microservices/media/services/fileService.js
@@ -1,0 +1,24 @@
+const { v4: uuidv4 } = require('uuid');
+const config = require('../config');
+const { generateUploadUrl, generateDownloadUrl } = require('./s3Service');
+const fileModel = require('../models/fileModel');
+
+async function createSignedUpload(fileName, contentType) {
+  const key = `${uuidv4()}-${fileName}`;
+  const url = await generateUploadUrl(key, contentType);
+  await fileModel.save({ key, fileName, contentType, createdAt: new Date().toISOString() });
+  return { url, key, expiresIn: config.aws.urlExpiry };
+}
+
+async function getSignedDownload(key) {
+  const meta = await fileModel.get(key);
+  if (!meta) {
+    const err = new Error('File not found');
+    err.status = 404;
+    throw err;
+  }
+  const url = await generateDownloadUrl(key);
+  return { url, expiresIn: config.aws.urlExpiry };
+}
+
+module.exports = { createSignedUpload, getSignedDownload };

--- a/microservices/media/services/s3Service.js
+++ b/microservices/media/services/s3Service.js
@@ -1,0 +1,30 @@
+const { S3Client, PutObjectCommand, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+const config = require('../config');
+
+const client = new S3Client({
+  region: config.aws.region,
+  credentials: {
+    accessKeyId: config.aws.accessKeyId,
+    secretAccessKey: config.aws.secretAccessKey,
+  },
+});
+
+async function generateUploadUrl(key, contentType) {
+  const command = new PutObjectCommand({
+    Bucket: config.aws.bucket,
+    Key: key,
+    ContentType: contentType,
+  });
+  return getSignedUrl(client, command, { expiresIn: config.aws.urlExpiry });
+}
+
+async function generateDownloadUrl(key) {
+  const command = new GetObjectCommand({
+    Bucket: config.aws.bucket,
+    Key: key,
+  });
+  return getSignedUrl(client, command, { expiresIn: config.aws.urlExpiry });
+}
+
+module.exports = { generateUploadUrl, generateDownloadUrl };

--- a/microservices/media/tests/files.test.js
+++ b/microservices/media/tests/files.test.js
@@ -1,0 +1,38 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Media Service', () => {
+  it('generates a signed upload URL', async () => {
+    const res = await request(app)
+      .post('/files/sign')
+      .send({ fileName: 'test.txt', contentType: 'text/plain' });
+    expect(res.status).toBe(200);
+    expect(res.body.url).toContain('X-Amz-Signature');
+    expect(res.body.url).toContain('X-Amz-Expires');
+    expect(res.body.key).toBeDefined();
+  });
+
+  it('generates a signed download URL', async () => {
+    const resSign = await request(app)
+      .post('/files/sign')
+      .send({ fileName: 'file.txt', contentType: 'text/plain' });
+    const key = resSign.body.key;
+
+    const res = await request(app).get(`/files/${key}`);
+    expect(res.status).toBe(200);
+    expect(res.body.url).toContain(key);
+    expect(res.body.url).toContain('X-Amz-Signature');
+  });
+
+  it('validates sign request', async () => {
+    const res = await request(app)
+      .post('/files/sign')
+      .send({ contentType: 'text/plain' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown file', async () => {
+    const res = await request(app).get('/files/unknown-key');
+    expect(res.status).toBe(404);
+  });
+});

--- a/microservices/media/utils/logger.js
+++ b/microservices/media/utils/logger.js
@@ -1,0 +1,21 @@
+const winston = require('winston');
+const config = require('../config');
+
+const logger = winston.createLogger({
+  level: config.logging.level,
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.errors({ stack: true }),
+    winston.format.simple()
+  ),
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.combine(
+        winston.format.colorize(),
+        winston.format.simple()
+      )
+    })
+  ]
+});
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- scaffold media service with Express
- support POST /files/sign and GET /files/:id using S3 presigned URLs
- enforce layered request flow with validation, logging and in-memory metadata

## Testing
- `cd microservices/media && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9a8e0e083268172f69798e2c3e8