### PR TITLE
Add OpenAPI documentation for microservices

### DIFF
--- a/microservices/analysis/openapi.yaml
+++ b/microservices/analysis/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Analysis Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /analysis/jobs:
+    post:
+      summary: Create analysis job
+      responses:
+        '200':
+          description: Job created
+  /analysis/{gameId}:
+    get:
+      summary: Get analysis for a game
+      parameters:
+        - in: path
+          name: gameId
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Analysis data

--- a/microservices/auth/openapi.yaml
+++ b/microservices/auth/openapi.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.0
+info:
+  title: Auth Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /auth/register:
+    post:
+      summary: Register a new user
+      responses:
+        '200':
+          description: Registered
+  /auth/login:
+    post:
+      summary: User login
+      responses:
+        '200':
+          description: Logged in
+  /auth/password-reset/request:
+    post:
+      summary: Request password reset
+      responses:
+        '200':
+          description: Reset requested
+  /auth/password-reset/confirm:
+    post:
+      summary: Confirm password reset
+      responses:
+        '200':
+          description: Password reset
+  /auth/logout:
+    post:
+      summary: Logout current user
+      responses:
+        '200':
+          description: Logged out
+  /auth/me:
+    get:
+      summary: Get current user profile
+      responses:
+        '200':
+          description: Profile data
+  /auth/refresh:
+    post:
+      summary: Refresh authentication token
+      responses:
+        '200':
+          description: Token refreshed
+  /auth/verify-email:
+    post:
+      summary: Verify email address
+      responses:
+        '200':
+          description: Email verified
+  /auth/change-password:
+    post:
+      summary: Change user password
+      responses:
+        '200':
+          description: Password changed

--- a/microservices/chat/openapi.yaml
+++ b/microservices/chat/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Chat Service API
+  version: 1.0.0
+paths:
+  /chat/history:
+    get:
+      summary: Retrieve chat history
+      responses:
+        '200':
+          description: Chat history
+  /presence/{user}:
+    get:
+      summary: Get presence status of a user
+      parameters:
+        - in: path
+          name: user
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Presence information

--- a/microservices/clubs/openapi.yaml
+++ b/microservices/clubs/openapi.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Clubs Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /clubs:
+    post:
+      summary: Create a club
+      responses:
+        '200':
+          description: Club created
+  /clubs/{id}/join:
+    post:
+      summary: Join a club
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Joined club
+  /clubs/{id}:
+    get:
+      summary: Get club information
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Club data

--- a/microservices/fairplay/openapi.yaml
+++ b/microservices/fairplay/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Fairplay Service API
+  version: 1.0.0
+paths:
+  /analyze:
+    post:
+      summary: Analyze a game for fairness
+      responses:
+        '200':
+          description: Analysis queued
+  /report:
+    post:
+      summary: Report suspected cheating
+      responses:
+        '200':
+          description: Report received
+  /flagged:
+    get:
+      summary: Get list of flagged games
+      responses:
+        '200':
+          description: Flagged games

--- a/microservices/game-coordinator/openapi.yaml
+++ b/microservices/game-coordinator/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Game Coordinator API
+  version: 1.0.0
+paths:
+  /games:
+    post:
+      summary: Create a game
+      responses:
+        '200':
+          description: Game created
+  /routing/{gameId}:
+    get:
+      summary: Get routing information for a game
+      parameters:
+        - in: path
+          name: gameId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Routing info

--- a/microservices/gateway-admin/openapi.yaml
+++ b/microservices/gateway-admin/openapi.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Gateway Admin API
+  version: 1.0.0
+paths:
+  /healthz:
+    get:
+      summary: Liveness probe
+      responses:
+        '200':
+          description: OK
+  /readyz:
+    get:
+      summary: Readiness probe
+      responses:
+        '200':
+          description: OK
+  /flags/{key}:
+    put:
+      summary: Update feature flag
+      parameters:
+        - in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Flag updated
+  /registry/:
+    get:
+      summary: List registered services
+      responses:
+        '200':
+          description: Registry list

--- a/microservices/media/openapi.yaml
+++ b/microservices/media/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Media Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /files/sign:
+    post:
+      summary: Request signed upload URL
+      responses:
+        '200':
+          description: Signed URL returned
+  /files/{id}:
+    get:
+      summary: Retrieve a file
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: File contents

--- a/microservices/notifications/openapi.yaml
+++ b/microservices/notifications/openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Notifications Service API
+  version: 1.0.0
+paths:
+  /notify:
+    post:
+      summary: Send a notification
+      responses:
+        '200':
+          description: Notification sent
+  /devices/register:
+    post:
+      summary: Register a device
+      responses:
+        '200':
+          description: Device registered

--- a/microservices/puzzle/openapi.yaml
+++ b/microservices/puzzle/openapi.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Puzzle Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /puzzles/next:
+    get:
+      summary: Get next puzzle
+      responses:
+        '200':
+          description: Puzzle data
+  /puzzle-rush/start:
+    post:
+      summary: Start a puzzle rush session
+      responses:
+        '200':
+          description: Session started
+  /puzzle-rush/move:
+    post:
+      summary: Submit a move in puzzle rush
+      responses:
+        '200':
+          description: Move accepted
+  /puzzle-rush/finish:
+    post:
+      summary: Finish a puzzle rush session
+      responses:
+        '200':
+          description: Session finished
+  /leaderboards/puzzle-rush:
+    get:
+      summary: Get puzzle rush leaderboard
+      responses:
+        '200':
+          description: Leaderboard data

--- a/microservices/rating/openapi.yaml
+++ b/microservices/rating/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Rating Service API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: Service is healthy
+  /ratings/{userId}:
+    get:
+      summary: Get ratings for a user
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ratings data
+  /ratings/recalc:
+    post:
+      summary: Recalculate ratings
+      responses:
+        '200':
+          description: Recalculation started

--- a/microservices/spectator/openapi.yaml
+++ b/microservices/spectator/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Spectator Service API
+  version: 1.0.0
+paths:
+  /games/{id}/state:
+    get:
+      summary: Get current game state
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Game state
+  /games/{id}/moves:
+    get:
+      summary: Get moves for a game
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Moves list

--- a/microservices/tournament/openapi.yaml
+++ b/microservices/tournament/openapi.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Tournament Service API
+  version: 1.0.0
+paths:
+  /tournaments:
+    post:
+      summary: Create a tournament
+      responses:
+        '200':
+          description: Tournament created
+  /tournaments/{id}/start:
+    post:
+      summary: Start a tournament
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Tournament started
+  /tournaments/{id}/standings:
+    get:
+      summary: Get tournament standings
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Standings data


### PR DESCRIPTION
## Summary
- add OpenAPI specifications for analysis, notifications, puzzle, gateway-admin, tournament, game-coordinator, fairplay, auth, chat, spectator, rating, clubs, and media microservices

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0c401c1348326b1b53f6fe0c8b426